### PR TITLE
AppVeyor: Fix creation of symblic links for good

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,9 +1,10 @@
 version: "{branch}-{build}"
 image: Visual Studio 2017
-init:
-- git config --global core.symlinks true
+clone_script:
+- git clone -c core.symlinks=true -q --branch=%APPVEYOR_REPO_BRANCH% --recursive https://github.com/%APPVEYOR_REPO_NAME%.git %APPVEYOR_BUILD_FOLDER%
+- del %APPVEYOR_BUILD_FOLDER%\datasets\spdx-*
+- git checkout %APPVEYOR_BUILD_FOLDER%\datasets\spdx-*
 install:
-- git submodule update --init --recursive
 - curl -sSf -o rustup-init.exe https://win.rustup.rs/
 - rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain stable
 - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin


### PR DESCRIPTION
*Description of changes:*

The main repository contains symbolic links to directories in the
submodule. As the submodule is initialized after the main repository, it
is unknown to Git whether the links point to files or directories. On
Windows, this is important to know as symbolic links can point to
either files or directories, and the type has to be known at the point of
their creation. The default is to create file symbolic links, which is
wrong in this case. So delete the symbolic links and check them out
again after the submodule has been initialized to get them recreated as
directory symbolic links.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
