### PR TITLE
Preproc improvements

### DIFF
--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -136,7 +136,7 @@ fn lcs_substr<'a>(f_line: &'a str, s_line: &'a str) -> &'a str {
     let common_len = f_line_chars
         .zip(s_line_chars)
         .take_while(|&((_i, f), s)| f == s)
-        .map(|((i, _f), _s)| i)
+        .map(|((i, f), _s)| i + f.len_utf8())
         .last()
         .unwrap_or(0);
     

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -127,19 +127,20 @@ fn trim(input: Cow<str>) -> Cow<str> {
 
 // Aggressive preprocessors
 
-fn lcs_substr(f_line: &str, s_line: &str) -> String {
+fn lcs_substr<'a>(f_line: &'a str, s_line: &'a str) -> &'a str {
     // grab character iterators from both strings
-    let f_line_chars = f_line.chars();
+    let f_line_chars = f_line.char_indices();
     let s_line_chars = s_line.chars();
 
     // zip them together and find the common substring from the start
-    f_line_chars
+    let common_len = f_line_chars
         .zip(s_line_chars)
-        .take_while(|&(f, s)| f == s)
-        .map(|(f, _s)| f)
-        .collect::<String>()
-        .trim()
-        .into() //TODO: big optimization needed, this is a wasteful conversion
+        .take_while(|&((_i, f), s)| f == s)
+        .map(|((i, _f), _s)| i)
+        .last()
+        .unwrap_or(0);
+    
+    f_line[..common_len].trim()
 }
 
 fn remove_common_tokens(input: Cow<str>) -> Cow<str> {

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -172,11 +172,10 @@ fn remove_common_tokens(input: Cow<str>) -> Cow<str> {
     }
 
     // look at the most common observed prefix
-    let max_prefix = prefix_counts.iter().max_by_key(|&(_k, v)| v);
-    if max_prefix.is_none() {
-        return input;
-    }
-    let (most_common, _) = max_prefix.unwrap();
+    let most_common = match prefix_counts.iter().max_by_key(|&(_k, v)| v) {
+        Some((prefix, _count)) => prefix,
+        None => return input,
+    };
 
     // reconcile the count with other longer prefixes that may be stored
     let mut final_common_count = 0;

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -189,17 +189,9 @@ fn remove_common_tokens(input: Cow<str>) -> Cow<str> {
     }
 
     // pass 2: remove that substring
-    let prefix_len = most_common.len();
     lines
         .iter()
-        .map(|line| {
-            if line.starts_with(most_common) {
-                &line[prefix_len..]
-            } else {
-                &line
-            }
-        })
-        .map(|line| line.trim())
+        .map(|s| s.trim_start_matches(most_common).trim())
         .collect::<Vec<_>>()
         .join("\n")
         .into()

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -193,16 +193,13 @@ fn remove_common_tokens(input: Cow<str>) -> Cow<str> {
     let (most_common, _) = max_prefix.unwrap();
 
     // reconcile the count with other longer prefixes that may be stored
-    let mut final_common_count = 0;
-    for (k, v) in prefix_counts.iter() {
-        if k.starts_with(most_common) {
-            final_common_count += v;
-        }
-    }
+    let common_count = prefix_counts.iter()
+        .filter_map(|(s, count)| Some(count).filter(|_| s.starts_with(most_common)))
+        .sum::<u32>();
 
     // the common string must be at least 80% of the text
-    let prefix_threshold: u32 = (0.8f32 * lines.len() as f32) as u32;
-    if final_common_count < prefix_threshold {
+    let prefix_threshold = (0.8f32 * lines.len() as f32) as _;
+    if common_count < prefix_threshold {
         return input;
     }
 

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -297,6 +297,40 @@ mod tests {
     use super::*;
 
     #[test]
+    fn trim_byte_adjusted_respects_multibyte_characters() {
+        let input = "RustКраб橙蟹🦀";
+        let expected = [
+            "",
+            "R",
+            "Ru",
+            "Rus",
+            "Rust",
+            "Rust",
+            "RustК",
+            "RustК",
+            "RustКр",
+            "RustКр",
+            "RustКра",
+            "RustКра",
+            "RustКраб",
+            "RustКраб",
+            "RustКраб",
+            "RustКраб橙",
+            "RustКраб橙",
+            "RustКраб橙",
+            "RustКраб橙蟹",
+            "RustКраб橙蟹",
+            "RustКраб橙蟹",
+            "RustКраб橙蟹",
+            "RustКраб橙蟹🦀",
+        ];
+
+        for (i, &outcome) in expected.iter().enumerate() {
+            assert_eq!(outcome, trim_byte_adjusted(input, i))
+        }
+    }
+
+    #[test]
     fn greatest_substring_removal() {
         // the funky string syntax \n\ is to add a newline but skip the
         // leading whitespace in the source code

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -136,9 +136,8 @@ fn lcs_substr<'a>(f_line: &'a str, s_line: &'a str) -> &'a str {
     let common_len = f_line_chars
         .zip(s_line_chars)
         .take_while(|&((_i, f), s)| f == s)
-        .map(|((i, f), _s)| i + f.len_utf8())
         .last()
-        .unwrap_or(0);
+        .map_or(0, |((i, f), _s)| i + f.len_utf8());
     
     f_line[..common_len].trim()
 }

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -178,21 +178,6 @@ fn remove_common_tokens(input: Cow<str>) -> Cow<str> {
     };
 
     // reconcile the count with other longer prefixes that may be stored
-    let mut final_common_count = 0;
-    for (k, v) in prefix_counts.iter() {
-        if k.starts_with(most_common) {
-            final_common_count += v;
-        }
-    }
-
-    // look at the most common observed prefix
-    let max_prefix = prefix_counts.iter().max_by_key(|&(_k, v)| v);
-    if max_prefix.is_none() {
-        return input;
-    }
-    let (most_common, _) = max_prefix.unwrap();
-
-    // reconcile the count with other longer prefixes that may be stored
     let common_count = prefix_counts.iter()
         .filter_map(|(s, count)| Some(count).filter(|_| s.starts_with(most_common)))
         .sum::<u32>();

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -151,12 +151,11 @@ fn remove_common_tokens(input: Cow<str>) -> Cow<str> {
     let mut prefix_counts = HashMap::<_, u32>::new();
 
     // pass 1: iterate through the text to record common prefixes
-    if let(Some(first), Some(second)) = (l_iter.next(), l_iter.next()) {
-        let mut pair = (first, second);
+    if let Some(first) = l_iter.next() {
+        let mut pair = ("", first);
         let line_pairs = std::iter::from_fn(|| {
-            let ret = pair;
             pair = (pair.1, l_iter.next()?);
-            Some(ret)
+            Some(pair)
         });
         for (a, b) in line_pairs {
             let common = lcs_substr(a, b);

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -189,7 +189,13 @@ fn remove_common_tokens(input: Cow<str>) -> Cow<str> {
     // pass 2: remove that substring
     lines
         .iter()
-        .map(|s| s.trim_start_matches(most_common).trim())
+        .map(|line| {
+            if line.starts_with(most_common) {
+                &line[most_common.len()..]
+            } else {
+                line
+            }.trim()
+        })
         .collect::<Vec<_>>()
         .join("\n")
         .into()


### PR DESCRIPTION
*Description of changes:*
This series of commits simplifies implementations of `lcs_substr` and `remove_common_tokens` as well as greatly reducing amount of memory allocations. Functionality is preserved, all tests pass.

Note: in `lcs_substr` the common prefix is `.trim()`ed. However, if this common prefix happens to start with whitespace characters, this will give wrong results later in `remove_common_tokens`. It seems like it actually should be `.trim_end()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
