### PR TITLE
chore: Bump rmp-serde to 0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ failure = "0.1.5"
 lazy_static = "1.3.0"
 log = "0.4.6"
 regex = "1.1.7"
-rmp-serde = "0.13.7"
+rmp-serde = "0.14.0"
 serde = { version = "1.0.92", features = ["derive"] }
 unicode-normalization = "0.1.8"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bump rmp-serde dependency to 0.14.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
